### PR TITLE
Fix README.md example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ rnr -f file renamed ./file-01.txt ./one/file-02.txt ./one/file-03.txt
 *Renamed tree*
 ```
 .
-├── file-01.txt
+├── renamed-01.txt
 ├── file-02.txt
 ├── file-03.txt
 └── one
     ├── file-01.txt
-    ├── file-02.txt
-    └── file-03.txt
+    ├── renamed-02.txt
+    └── renamed-03.txt
 ```
 
 #### Include directories


### PR DESCRIPTION
Looks like there's a copy paste error in one of the examples in the README file. Running the example command for real does what you'd expect it too: 

```
> tree
.
├── file-01.txt
├── file-02.txt
├── file-03.txt
└── one
    ├── file-01.txt
    ├── file-02.txt
    └── file-03.txt

1 directory, 6 files
> rnr -f file renamed ./file-01.txt ./one/file-02.txt ./one/file-03.txt
./one/file-03.txt -> ./one/renamed-03.txt
./one/file-02.txt -> ./one/renamed-02.txt
./file-01.txt -> ./renamed-01.txt
> tree
.
├── file-02.txt
├── file-03.txt
├── one
│   ├── file-01.txt
│   ├── renamed-02.txt
│   └── renamed-03.txt
├── renamed-01.txt
└── rnr-2020-07-17_213630.json
```

1 directory, 7 files