### PR TITLE
feat: Add vidir-like editor subcommand, auto-create parent dirs on rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Unreleased
+### Added
+* Automatically create missing parent directories when the target path of a
+  rename operation requires them (e.g. renaming `file.txt` to
+  `archive/2024/file.txt` creates `archive/2024/` on the fly).
+* New `editor` subcommand: interactive rename (and optional delete) of files
+  using your preferred text editor, similar to `vidir`.
+  * Opens a temporary file (in the OS temp directory) containing one path per
+    line and waits for the editor to exit.
+  * Without `--delete`: line count must be preserved; each edited line renames
+    the corresponding source path.
+  * With `--delete`: lines are prefixed with a 1-based index and a tab
+    (`INDEX<TAB>PATH`); removing a line deletes the file.
+  * Editor is selected via `--editor <CMD>`, then `$VISUAL`, then `$EDITOR`,
+    defaulting to `vi`.
+  * Supports `-r` / `--recursive`, `-d` / `--max-depth`, `-x` / `--hidden`,
+    and `-D` / `--include-dirs` just like the `regex` subcommand.
+
 ## V0.5.1 (2025-12-13)
 ### Fixed
 * Order of rename operations when renaming directories

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,22 @@ pub enum SubCommands {
         #[command(flatten)]
         path: PathArgs,
     },
+    /// Edit file names in an interactive text editor (similar to vidir).
+    #[command(arg_required_else_help = true)]
+    Editor {
+        #[command(flatten)]
+        common: CommonArgs,
+
+        #[command(flatten)]
+        path: PathArgs,
+
+        /// Enable file deletion by removing lines in the editor.
+        #[arg(long)]
+        delete: bool,
+        /// Editor command to use. Defaults to $VISUAL, then $EDITOR, then 'vi'.
+        #[arg(long, value_name = "CMD")]
+        editor: Option<String>,
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,0 +1,300 @@
+use crate::error::*;
+use crate::solver::{Operation, Operations};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::Builder;
+
+/// Result of the editor interaction: rename operations and paths to delete.
+#[derive(Debug)]
+pub struct EditorResult {
+    pub operations: Operations,
+    pub deletions: Vec<PathBuf>,
+}
+
+/// Open the given paths in a text editor and return the resulting rename/delete operations.
+///
+/// When `allow_delete` is `false` the temp file lists bare paths one per line and the line
+/// count must match after editing (an error is raised otherwise).
+///
+/// When `allow_delete` is `true` each line is prefixed with a 1-based index and a tab
+/// (`INDEX\tPATH`).  Removing a line deletes the corresponding file; changing the path after
+/// the tab renames it.
+pub fn open_editor(paths: &[PathBuf], editor: &str, allow_delete: bool) -> Result<EditorResult> {
+    // Build the content that will be shown in the editor
+    let content: String = if allow_delete {
+        paths
+            .iter()
+            .enumerate()
+            .map(|(i, p)| format!("{}\t{}", i + 1, p.display()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // Write content to a named temporary file so the editor can open it by path
+    let mut temp_file = Builder::new()
+        .prefix("rnr-editor-")
+        .suffix(".txt")
+        .tempfile()
+        .map_err(|e| Error {
+            kind: ErrorKind::CreateFile,
+            value: Some(format!("temporary file: {}", e)),
+        })?;
+
+    temp_file
+        .write_all(content.as_bytes())
+        .map_err(|e| Error {
+            kind: ErrorKind::CreateFile,
+            value: Some(format!("write temporary file: {}", e)),
+        })?;
+    // Flush so the editor sees the content
+    temp_file.flush().map_err(|e| Error {
+        kind: ErrorKind::CreateFile,
+        value: Some(format!("flush temporary file: {}", e)),
+    })?;
+
+    let temp_path = temp_file.path().to_path_buf();
+
+    // Launch editor and wait for it to finish
+    let status = Command::new(editor)
+        .arg(&temp_path)
+        .status()
+        .map_err(|e| Error {
+            kind: ErrorKind::EditorCommand,
+            value: Some(format!("'{}': {}", editor, e)),
+        })?;
+
+    if !status.success() {
+        return Err(Error {
+            kind: ErrorKind::EditorCommand,
+            value: Some(format!("'{}' exited with status {}", editor, status)),
+        });
+    }
+
+    // Read the edited content back
+    let edited_content = std::fs::read_to_string(&temp_path).map_err(|e| Error {
+        kind: ErrorKind::ReadFile,
+        value: Some(format!("{}: {}", temp_path.display(), e)),
+    })?;
+
+    let edited_lines: Vec<&str> = edited_content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    if allow_delete {
+        parse_with_delete(paths, &edited_lines)
+    } else {
+        parse_without_delete(paths, &edited_lines)
+    }
+}
+
+/// Parse editor output when deletion is NOT allowed.
+/// Each line must correspond positionally to the original path list.
+fn parse_without_delete(paths: &[PathBuf], edited_lines: &[&str]) -> Result<EditorResult> {
+    if paths.len() != edited_lines.len() {
+        return Err(Error {
+            kind: ErrorKind::EditorLineCount,
+            value: Some(format!(
+                "expected {} lines but got {}. Use --delete to enable deletion.",
+                paths.len(),
+                edited_lines.len()
+            )),
+        });
+    }
+
+    let mut operations = Operations::new();
+    for (source, new_line) in paths.iter().zip(edited_lines.iter()) {
+        let target = PathBuf::from(new_line.trim());
+        if *source != target {
+            operations.push(Operation {
+                source: source.clone(),
+                target,
+            });
+        }
+    }
+
+    Ok(EditorResult {
+        operations,
+        deletions: vec![],
+    })
+}
+
+/// Parse editor output when deletion IS allowed.
+/// Lines have the format `INDEX\tPATH`.  Missing indices mean deletion.
+fn parse_with_delete(paths: &[PathBuf], edited_lines: &[&str]) -> Result<EditorResult> {
+    use std::collections::HashMap;
+
+    let mut index_to_new_path: HashMap<usize, PathBuf> = HashMap::new();
+
+    for line in edited_lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match line.find('\t') {
+            None => {
+                return Err(Error {
+                    kind: ErrorKind::EditorLineCount,
+                    value: Some(format!(
+                        "line '{}' is missing the index prefix (expected 'INDEX<TAB>PATH')",
+                        line
+                    )),
+                });
+            }
+            Some(tab_pos) => {
+                let index_str = line[..tab_pos].trim();
+                let path_str = line[tab_pos + 1..].trim();
+                let index: usize = index_str.parse().map_err(|_| Error {
+                    kind: ErrorKind::EditorLineCount,
+                    value: Some(format!("invalid index '{}' in line '{}'", index_str, line)),
+                })?;
+                if index < 1 || index > paths.len() {
+                    return Err(Error {
+                        kind: ErrorKind::EditorLineCount,
+                        value: Some(format!(
+                            "index {} is out of range (1–{})",
+                            index,
+                            paths.len()
+                        )),
+                    });
+                }
+                if index_to_new_path
+                    .insert(index, PathBuf::from(path_str))
+                    .is_some()
+                {
+                    return Err(Error {
+                        kind: ErrorKind::EditorLineCount,
+                        value: Some(format!("duplicate index {} in editor output", index)),
+                    });
+                }
+            }
+        }
+    }
+
+    let mut operations = Operations::new();
+    let mut deletions = Vec::new();
+
+    for (i, source) in paths.iter().enumerate() {
+        let index = i + 1;
+        match index_to_new_path.get(&index) {
+            Some(target) => {
+                if source != target {
+                    operations.push(Operation {
+                        source: source.clone(),
+                        target: target.clone(),
+                    });
+                }
+            }
+            None => {
+                deletions.push(source.clone());
+            }
+        }
+    }
+
+    Ok(EditorResult {
+        operations,
+        deletions,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn paths(names: &[&str]) -> Vec<PathBuf> {
+        names.iter().map(|n| PathBuf::from(n)).collect()
+    }
+
+    // --- parse_without_delete ---
+
+    #[test]
+    fn no_delete_unchanged() {
+        let p = paths(&["/tmp/a.txt", "/tmp/b.txt"]);
+        let lines = vec!["/tmp/a.txt", "/tmp/b.txt"];
+        let result = parse_without_delete(&p, &lines).unwrap();
+        assert!(result.operations.is_empty());
+        assert!(result.deletions.is_empty());
+    }
+
+    #[test]
+    fn no_delete_rename() {
+        let p = paths(&["/tmp/a.txt", "/tmp/b.txt"]);
+        let lines = vec!["/tmp/a_new.txt", "/tmp/b.txt"];
+        let result = parse_without_delete(&p, &lines).unwrap();
+        assert_eq!(result.operations.len(), 1);
+        assert_eq!(result.operations[0].source, PathBuf::from("/tmp/a.txt"));
+        assert_eq!(result.operations[0].target, PathBuf::from("/tmp/a_new.txt"));
+        assert!(result.deletions.is_empty());
+    }
+
+    #[test]
+    fn no_delete_wrong_line_count_error() {
+        let p = paths(&["/tmp/a.txt", "/tmp/b.txt"]);
+        let lines = vec!["/tmp/a.txt"]; // one line missing
+        let err = parse_without_delete(&p, &lines).unwrap_err();
+        assert_eq!(err.kind, ErrorKind::EditorLineCount);
+    }
+
+    // --- parse_with_delete ---
+
+    #[test]
+    fn with_delete_unchanged() {
+        let p = paths(&["/tmp/a.txt", "/tmp/b.txt"]);
+        let lines = vec!["1\t/tmp/a.txt", "2\t/tmp/b.txt"];
+        let result = parse_with_delete(&p, &lines).unwrap();
+        assert!(result.operations.is_empty());
+        assert!(result.deletions.is_empty());
+    }
+
+    #[test]
+    fn with_delete_rename() {
+        let p = paths(&["/tmp/a.txt", "/tmp/b.txt"]);
+        let lines = vec!["1\t/tmp/a_new.txt", "2\t/tmp/b.txt"];
+        let result = parse_with_delete(&p, &lines).unwrap();
+        assert_eq!(result.operations.len(), 1);
+        assert_eq!(result.operations[0].source, PathBuf::from("/tmp/a.txt"));
+        assert_eq!(result.operations[0].target, PathBuf::from("/tmp/a_new.txt"));
+        assert!(result.deletions.is_empty());
+    }
+
+    #[test]
+    fn with_delete_delete_file() {
+        let p = paths(&["/tmp/a.txt", "/tmp/b.txt"]);
+        let lines = vec!["1\t/tmp/a.txt"]; // b.txt line removed
+        let result = parse_with_delete(&p, &lines).unwrap();
+        assert!(result.operations.is_empty());
+        assert_eq!(result.deletions, vec![PathBuf::from("/tmp/b.txt")]);
+    }
+
+    #[test]
+    fn with_delete_invalid_index_error() {
+        let p = paths(&["/tmp/a.txt"]);
+        let lines = vec!["99\t/tmp/a.txt"]; // index out of range
+        let err = parse_with_delete(&p, &lines).unwrap_err();
+        assert_eq!(err.kind, ErrorKind::EditorLineCount);
+    }
+
+    #[test]
+    fn with_delete_missing_tab_error() {
+        let p = paths(&["/tmp/a.txt"]);
+        let lines = vec!["/tmp/a.txt"]; // no tab separator
+        let err = parse_with_delete(&p, &lines).unwrap_err();
+        assert_eq!(err.kind, ErrorKind::EditorLineCount);
+    }
+
+    #[test]
+    fn with_delete_duplicate_index_error() {
+        let p = paths(&["/tmp/a.txt", "/tmp/b.txt"]);
+        let lines = vec!["1\t/tmp/a.txt", "1\t/tmp/b_new.txt"]; // duplicate index 1
+        let err = parse_with_delete(&p, &lines).unwrap_err();
+        assert_eq!(err.kind, ErrorKind::EditorLineCount);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,11 @@ pub struct Error {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
     CreateBackup,
+    CreateDir,
     CreateFile,
     CreateSymlink,
+    EditorCommand,
+    EditorLineCount,
     ExistingPath,
     JsonParse,
     ReadFile,
@@ -30,8 +33,11 @@ impl Error {
         use self::ErrorKind::*;
         match self.kind {
             CreateBackup => "Cannot create a backup of ",
+            CreateDir => "Cannot create directory ",
             CreateFile => "Cannot create file ",
             CreateSymlink => "Cannot create symlink ",
+            EditorCommand => "Failed to run editor ",
+            EditorLineCount => "Unexpected line count in editor output: ",
             ExistingPath => "Conflict with existing path ",
             JsonParse => "Cannot parse JSON file ",
             ReadFile => "Cannot open/read file ",

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use crate::renamer::Renamer;
 mod cli;
 mod config;
 mod dumpfile;
+mod editor;
 mod error;
 mod fileutils;
 mod output;
@@ -53,8 +54,8 @@ fn main() {
     };
 
     // Generate operations
-    let operations = match renamer.process() {
-        Ok(operations) => operations,
+    let (operations, deletions) = match renamer.process() {
+        Ok(result) => result,
         Err(err) => {
             config.printer.print_error(&err);
             std::process::exit(1);
@@ -63,6 +64,12 @@ fn main() {
 
     // Batch rename operations
     if let Err(err) = renamer.batch_rename(operations) {
+        config.printer.print_error(&err);
+        std::process::exit(1);
+    }
+
+    // Batch delete operations (only populated for editor mode with --delete)
+    if let Err(err) = renamer.batch_delete(deletions) {
         config.printer.print_error(&err);
         std::process::exit(1);
     }


### PR DESCRIPTION
* Add vidir-like editor subcommand to rnr
* Auto-create missing parent directories when renaming to a new path
* docs: document editor subcommand in README and CHANGELOG

---------

Co-authored-by: copilot-swe-agent